### PR TITLE
Fix missing access modifiers to allow creating subclasses

### DIFF
--- a/src/search/ranking/RankingMethod.java
+++ b/src/search/ranking/RankingMethod.java
@@ -13,9 +13,10 @@ import core.TestSample;
  * 
  */
 public abstract class RankingMethod {
-	ArrayList<RankedResult> results;
-	int maxTopResults = Integer.MAX_VALUE;
-	String name;
+
+	protected ArrayList<RankedResult> results;
+	protected int maxTopResults = Integer.MAX_VALUE;
+	protected String name;
 
 	/**
 	 * Sets a new set of results for this ranking method
@@ -40,12 +41,12 @@ public abstract class RankingMethod {
 	 * @param maxTopResults
 	 *            The number of top results to keep
 	 */
-	RankingMethod(int maxTopResults) {
+	public RankingMethod(int maxTopResults) {
 		this.maxTopResults = maxTopResults;
 		results = new ArrayList<RankedResult>();
 	}
 	
-	RankingMethod(int maxTopResults, String name) {
+	public RankingMethod(int maxTopResults, String name) {
 		this.maxTopResults = maxTopResults;
 		results = new ArrayList<RankedResult>();
 		this.name = name;
@@ -78,7 +79,7 @@ public abstract class RankingMethod {
 	 * results
 	 * @param sample 
 	 */
-	void cutResultSetToTopHits(TestSample sample) {
+	protected void cutResultSetToTopHits(TestSample sample) {
 		ArrayList<RankedResult> topResults = new ArrayList<RankedResult>();
 
 		int numResults = 0;

--- a/src/search/ranking/results/RankedResult.java
+++ b/src/search/ranking/results/RankedResult.java
@@ -14,7 +14,7 @@ import core.Haplogroup;
  */
 
 public abstract class RankedResult implements Comparable<RankedResult> {
-	SearchResult searchResult;
+	protected SearchResult searchResult;
 	private Haplogroup expectedHaplogroup;
 
 	/**
@@ -25,7 +25,7 @@ public abstract class RankedResult implements Comparable<RankedResult> {
 	 * @param expectedHaplogroup
 	 *            The haplogroup expected for this result
 	 */
-	RankedResult(SearchResult searchResult, Haplogroup expectedHaplogroup) {
+	public RankedResult(SearchResult searchResult, Haplogroup expectedHaplogroup) {
 		this.searchResult = searchResult;
 		this.expectedHaplogroup = expectedHaplogroup;
 	}


### PR DESCRIPTION
Fixed access modifiers allow to create new metrics/distances outside of haplogrep-core